### PR TITLE
Fix path handling in docs generation script

### DIFF
--- a/src/update_modules_rst_file.py
+++ b/src/update_modules_rst_file.py
@@ -1,25 +1,48 @@
+from __future__ import annotations
+
 import os
+from pathlib import Path
 
-# Paths to directories
-source_dir = "/home/vetinari/Desktop/git/arcanumpy/src/rst_files"
-output_dir = "/home/vetinari/Desktop/git/arcanumpy/src/rst_files"
-output_module_file = os.path.join(output_dir, "modules.rst")
 
-# Scan for all .rst files (exclude index.rst itself)
-rst_files = [
-    f for f in os.listdir(source_dir) if f.endswith(".rst") and f != "modules.rst"
-]
+def update_modules_rst_file(source_dir: Path | str | None = None,
+                            output_dir: Path | str | None = None) -> Path:
+    """Generate ``modules.rst`` from RST files in ``source_dir``.
 
-# Write to index.rst
-with open(output_module_file, "w") as module_file:
-    # module_file.write("=========\n")
-    # module_file.write("Functions\n")
-    # module_file.write("=========\n\n")
-    module_file.write(".. toctree::\n")
-    module_file.write("   :maxdepth: 3\n\n")
-    for rst in sorted(rst_files):
-        module_name = os.path.splitext(rst)[0]  # Remove the .rst extension
-        module_file.write(f"   {module_name} <./rst_files/{module_name}.rst>\n")
+    Parameters
+    ----------
+    source_dir:
+        Directory containing individual ``.rst`` files.  Defaults to the
+        ``rst_files`` directory next to this script.
+    output_dir:
+        Destination directory for the resulting ``modules.rst`` file.  Defaults
+        to the ``rst_files`` directory.
 
-        module_name = os.path.splitext(rst)[0]  # Remove the .rst extension
-        module_rst_path = os.path.join(source_dir, rst)
+    Returns
+    -------
+    Path
+        Path to the generated ``modules.rst`` file.
+    """
+
+    base_dir = Path(__file__).resolve().parent
+    source_path = Path(source_dir) if source_dir is not None else base_dir / "rst_files"
+    output_path = Path(output_dir) if output_dir is not None else base_dir / "rst_files"
+    output_module_file = output_path / "modules.rst"
+
+    rst_files = [
+        f for f in os.listdir(source_path) if f.endswith(".rst") and f != "modules.rst"
+    ]
+
+    with open(output_module_file, "w") as module_file:
+        module_file.write(".. toctree::\n")
+        module_file.write("   :maxdepth: 3\n\n")
+        for rst in sorted(rst_files):
+            module_name = os.path.splitext(rst)[0]
+            module_file.write(
+                f"   {module_name} <./rst_files/{module_name}.rst>\n"
+            )
+
+    return output_module_file
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    update_modules_rst_file()

--- a/src/update_modules_rst_file_cosmere.py
+++ b/src/update_modules_rst_file_cosmere.py
@@ -1,29 +1,51 @@
+from __future__ import annotations
+
 import os
+from pathlib import Path
 
-# Paths to directories
-source_dir = "/home/cephadrius/Desktop/git/arcanumpy/src/rst_files"
-output_dir = "/home/cephadrius/Desktop/git/arcanumpy/src/"
-output_module_file = os.path.join(output_dir, "functions.rst")
 
-# Scan for all .rst files (exclude index.rst itself)
-rst_files = [
-    f for f in os.listdir(source_dir) if f.endswith(".rst") and f != "functions.rst"
-]
+def update_functions_rst_file(source_dir: Path | str | None = None,
+                              output_dir: Path | str | None = None) -> Path:
+    """Generate ``functions.rst`` from the RST files in ``source_dir``.
 
-# Write to index.rst
-with open(output_module_file, "w") as module_file:
-    module_file.write("=========\n")
-    module_file.write("Functions\n")
-    module_file.write("=========\n\n")
-    module_file.write(".. toctree::\n")
-    module_file.write("   :maxdepth: 3\n\n")
-    for rst in sorted(rst_files):
-        module_name = os.path.splitext(rst)[0]  # Remove the .rst extension
-        # Remove "arcanumpy." from the module name
-        # if module_name.startswith("arcanumpy."):
-        #     module_name = module_name[len("arcanumpy.") :]
+    Parameters
+    ----------
+    source_dir:
+        Directory containing individual ``.rst`` files.  When ``None`` the
+        ``rst_files`` directory located next to this script is used.
+    output_dir:
+        Directory in which to place the generated ``functions.rst`` file.  When
+        ``None`` the directory containing this script is used.
 
-        module_file.write(f"   {module_name} <./rst_files/{module_name}.rst>\n")
+    Returns
+    -------
+    Path
+        Path to the generated ``functions.rst`` file.
+    """
 
-        module_name = os.path.splitext(rst)[0]  # Remove the .rst extension
-        module_rst_path = os.path.join(source_dir, rst)
+    base_dir = Path(__file__).resolve().parent
+    source_path = Path(source_dir) if source_dir is not None else base_dir / "rst_files"
+    output_path = Path(output_dir) if output_dir is not None else base_dir
+    output_module_file = output_path / "functions.rst"
+
+    rst_files = [
+        f for f in os.listdir(source_path) if f.endswith(".rst") and f != "functions.rst"
+    ]
+
+    with open(output_module_file, "w") as module_file:
+        module_file.write("=========\n")
+        module_file.write("Functions\n")
+        module_file.write("=========\n\n")
+        module_file.write(".. toctree::\n")
+        module_file.write("   :maxdepth: 3\n\n")
+        for rst in sorted(rst_files):
+            module_name = os.path.splitext(rst)[0]
+            module_file.write(
+                f"   {module_name} <./rst_files/{module_name}.rst>\n"
+            )
+
+    return output_module_file
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    update_functions_rst_file()


### PR DESCRIPTION
## Summary
- remove hard-coded absolute paths from documentation generators and replace with configurable path-aware functions
- update unit test to load script dynamically and verify `functions.rst` generation

## Testing
- `pytest -q`
- `pip install flake8` *(failed: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_688f50dc493c8328897dfab6bceb997c