### PR TITLE
Fix typo in seaborn plots comment

### DIFF
--- a/arcanumpy/seaborn_plots_fncs.py
+++ b/arcanumpy/seaborn_plots_fncs.py
@@ -56,7 +56,7 @@ def kde_plots(
         axs1.plot_joint(sns.scatterplot, s=marker_size, alpha=alpha, color=color)
 
     # If var_marker_size is true, then make a concentric circle to show the size of the data points.
-    # Make srue that the circles do not have a facecolor
+    # Make sure that the circles do not have a facecolor
     if var_marker_size:
         radii_min = np.sqrt(np.nanmin(marker_size) / 3)
         radii_max = np.sqrt(np.nanmax(marker_size) / 3)


### PR DESCRIPTION
## Summary
- fix typo in seaborn_plots_fncs comment so circles do not have facecolor

## Testing
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: '/home/cephadrius/Desktop/git/arcanumpy/src/rst_files')*

------
https://chatgpt.com/codex/tasks/task_e_688f57733f008328a969f94616d201a9