### PR TITLE
Clarify log scale filtering in seaborn plot function

### DIFF
--- a/arcanumpy/seaborn_plots_fncs.py
+++ b/arcanumpy/seaborn_plots_fncs.py
@@ -43,7 +43,7 @@ def kde_plots(
     clabelsize = 20
     ticklength = 15
 
-    # Remove all occurances of delta_beta where delta_beta is less than 0
+    # When plotting on a log scale, remove rows where x <= 0 or y <= 0
     if log_scale:
         df = df[df[x] > 0]
         df = df[df[y] > 0]


### PR DESCRIPTION
## Summary
- clarify that non-positive rows are dropped when log-scale plotting is requested

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/home/cephadrius/Desktop/git/arcanumpy/src/rst_files')*

------
https://chatgpt.com/codex/tasks/task_e_688f5707d5e88328af6e53ba16db84a9