### PR TITLE
test: refactor functions index test to use tmp path

### DIFF
--- a/arcanumpy/tests/test_arcanumpy.py
+++ b/arcanumpy/tests/test_arcanumpy.py
@@ -1,34 +1,39 @@
 # Test file for arcanumpy
-#
 
 import os
-import sys
-import unittest
-from unittest.mock import patch
-from arcanumpy import arcanumpy
+import builtins
+import runpy
+from pathlib import Path
 
 
-def test_update_modules_rst_file_cosmere():
-    source_dir = "/home/cephadrius/Desktop/git/arcanumpy/src/rst_files"
-    output_dir = "/home/cephadrius/Desktop/git/arcanumpy/src/"
-    output_module_file = os.path.join(output_dir, "functions.rst")
+def test_update_modules_rst_file_cosmere(tmp_path, monkeypatch):
+    """Ensure the documentation index is generated correctly."""
 
-    rst_files = [
-        f for f in os.listdir(source_dir) if f.endswith(".rst") and f != "functions.rst"
-    ]
+    rst_dir = tmp_path / "rst_files"
+    rst_dir.mkdir()
+    for name in ("alpha.rst", "beta.rst"):
+        (rst_dir / name).write_text("")
 
-    with open(output_module_file, "w") as module_file:
-        module_file.write("=========\n")
-        module_file.write("Functions\n")
-        module_file.write("=========\n\n")
-        module_file.write(".. toctree::\n")
-        module_file.write("   :maxdepth: 3\n\n")
-        for rst in sorted(rst_files):
-            module_name = os.path.splitext(rst)[0]
+    output_file = tmp_path / "functions.rst"
 
-            module_file.write(f"   {module_name} <./rst_files/{module_name}.rst>\n")
+    original_listdir = os.listdir
+    monkeypatch.setattr(os, "listdir", lambda _:
+                        original_listdir(rst_dir))
 
-            module_name = os.path.splitext(rst)[0]
-            module_rst_path = os.path.join(source_dir, rst)
+    original_open = builtins.open
 
-    assert os.path.exists(output_module_file)
+    def fake_open(file, mode="r", *args, **kwargs):
+        if "w" in mode:
+            return original_open(output_file, mode, *args, **kwargs)
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    script_path = Path(__file__).resolve().parents[2] / "src" / "update_modules_rst_file_cosmere.py"
+    runpy.run_path(str(script_path))
+
+    assert output_file.exists()
+    content = output_file.read_text()
+    assert "alpha <./rst_files/alpha.rst>" in content
+    assert "beta <./rst_files/beta.rst>" in content
+


### PR DESCRIPTION
## Summary
- rewrite functions index test to use a temporary directory
- invoke update_modules script and verify generated toctree entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f574aec4483289f49ff37bc7cacc8